### PR TITLE
Fix permissions errors when creating watches

### DIFF
--- a/controllers/objecttemplate_controller.go
+++ b/controllers/objecttemplate_controller.go
@@ -194,11 +194,11 @@ func (r *ObjectTemplateReconciler) doReconcile(ctx context.Context, rt *template
 	newObjects := map[templatesv1alpha1.ObjectRef]struct{}{}
 	for _, me := range rt.Spec.Matrix {
 		if me.Object != nil {
-			newObjects[me.Object.Ref] = struct{}{}
-			err = wt.addWatchForObject(ctx, me.Object.Ref)
+			refWithNs, err := wt.addWatchForObject(ctx, me.Object.Ref)
 			if err != nil {
 				return err
 			}
+			newObjects[refWithNs] = struct{}{}
 		}
 	}
 	wt.removeDeletedWatches(ctx, newObjects)

--- a/controllers/objecttemplate_controller.go
+++ b/controllers/objecttemplate_controller.go
@@ -32,6 +32,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -234,11 +235,11 @@ func (r *ObjectTemplateReconciler) doReconcile(ctx context.Context, rt *template
 	}
 
 	for _, x := range allResources {
-		rm, err := r.Client.RESTMapper().RESTMapping(x.GroupVersionKind().GroupKind(), x.GroupVersionKind().Version)
+		isNs, err := apiutil.IsGVKNamespaced(x.GroupVersionKind(), objClient.RESTMapper())
 		if err != nil {
 			return err
 		}
-		if rm.Scope.Name() == apimeta.RESTScopeNameNamespace && x.GetNamespace() == "" {
+		if isNs && x.GetNamespace() == "" {
 			x.SetNamespace(rt.Namespace)
 		}
 	}

--- a/controllers/texttemplate_controller.go
+++ b/controllers/texttemplate_controller.go
@@ -129,29 +129,25 @@ func (r *TextTemplateReconciler) doReconcile(ctx context.Context, tt *templatesv
 	wt.setClient(ctx, objClient, tt.Spec.ServiceAccountName)
 	newObjects := map[templatesv1alpha1.ObjectRef]struct{}{}
 	if tt.Spec.TemplateRef != nil && tt.Spec.TemplateRef.ConfigMap != nil {
-		ns := tt.Spec.TemplateRef.ConfigMap.Namespace
-		if ns == "" {
-			ns = tt.Namespace
-		}
 		objRef := templatesv1alpha1.ObjectRef{
 			APIVersion: "v1",
 			Kind:       "ConfigMap",
-			Namespace:  ns,
+			Namespace:  tt.Spec.TemplateRef.ConfigMap.Namespace,
 			Name:       tt.Spec.TemplateRef.ConfigMap.Name,
 		}
-		err = wt.addWatchForObject(ctx, objRef)
+		refWithNs, err := wt.addWatchForObject(ctx, objRef)
 		if err != nil {
 			return err
 		}
-		newObjects[objRef] = struct{}{}
+		newObjects[refWithNs] = struct{}{}
 	}
 	for _, me := range tt.Spec.Inputs {
 		if me.Object != nil {
-			err = wt.addWatchForObject(ctx, me.Object.Ref)
+			refWithNs, err := wt.addWatchForObject(ctx, me.Object.Ref)
 			if err != nil {
 				return err
 			}
-			newObjects[me.Object.Ref] = struct{}{}
+			newObjects[refWithNs] = struct{}{}
 		}
 	}
 	wt.removeDeletedWatches(ctx, newObjects)

--- a/controllers/texttemplate_controller_test.go
+++ b/controllers/texttemplate_controller_test.go
@@ -103,6 +103,15 @@ var _ = Describe("TextTemplate controller", func() {
 			Expect(c.Status).To(Equal(metav1.ConditionTrue))
 			assertTextTemplateResult(key, "v1")
 		})
+		It("Should still succeed when the input object has no namespace", func() {
+			updateTextTemplate(key, func(t *templatesv1alpha1.TextTemplate) {
+				t.Spec.Inputs[0].Object.Ref.Namespace = ""
+			})
+			waitUntiTextTemplateReconciled(key, timeout)
+			t2 := getTextTemplate(key)
+			c := getReadyCondition(t2.GetConditions())
+			Expect(c.Status).To(Equal(metav1.ConditionTrue))
+		})
 		It("Should respect the jsonPath", func() {
 			updateTextTemplate(key, func(t *templatesv1alpha1.TextTemplate) {
 				p := ".data"


### PR DESCRIPTION
This fixes an issue with "permission denied" being reported when the
namespace field is missing in matrix entries. The expected behavior is
that the namespace of the template resource is used when the input
object namespace is omitted.
